### PR TITLE
Refactor test_reuse_key - Fix #6

### DIFF
--- a/certbot/tests/main_test.py
+++ b/certbot/tests/main_test.py
@@ -1089,11 +1089,6 @@ class MainTest(test_util.ConfigTestCase):  # pylint: disable=too-many-public-met
         args = ["renew", "--dry-run", "-tvv"]
         self._test_renewal_common(True, [], args=args, should_renew=True)
 
-    # Should be moved to renewal_test.py
-    def test_reuse_key(self):
-        test_util.make_lineage(self.config.config_dir, 'sample-renewal.conf')
-        args = ["renew", "--dry-run", "--reuse-key"]
-        self._test_renewal_common(True, [], args=args, should_renew=True, reuse_key=True)
 
     # Should be moved to renewal_test.py
     @mock.patch('certbot.storage.RenewableCert.save_successor')

--- a/certbot/tests/renewal_test.py
+++ b/certbot/tests/renewal_test.py
@@ -38,7 +38,6 @@ class RenewalTest(test_util.ConfigTestCase):
         args = ["renew", "--dry-run", "--reuse-key"]
         self._test_renewal_common(True, [], args=args, should_renew=True, reuse_key=True)
 
-
     def _call(self, args, stdout=None, mockisfile=False):
         """Run the cli with output streams, actual client and optionally
         os.path.isfile() mocked out"""

--- a/certbot/tests/renewal_test.py
+++ b/certbot/tests/renewal_test.py
@@ -33,6 +33,12 @@ class RenewalTest(test_util.ConfigTestCase):
             with open(log_path) as lf:
                 print(lf.read())
 
+    def test_reuse_key(self):
+        test_util.make_lineage(self.config.config_dir, 'sample-renewal.conf')
+        args = ["renew", "--dry-run", "--reuse-key"]
+        self._test_renewal_common(True, [], args=args, should_renew=True, reuse_key=True)
+
+
     def _call(self, args, stdout=None, mockisfile=False):
         """Run the cli with output streams, actual client and optionally
         os.path.isfile() mocked out"""


### PR DESCRIPTION
Moved test_reuse_key() to renewal_test.py. The test_reuse_key() is quite simple and straight forward so I didn't find the need for refactoring it.