### PR TITLE
Refactor test_reuse_key_no_dry_run() #7

### DIFF
--- a/certbot/tests/main_test.py
+++ b/certbot/tests/main_test.py
@@ -1096,13 +1096,6 @@ class MainTest(test_util.ConfigTestCase):  # pylint: disable=too-many-public-met
         self._test_renewal_common(True, [], args=args, should_renew=True, reuse_key=True)
 
     # Should be moved to renewal_test.py
-    @mock.patch('certbot.storage.RenewableCert.save_successor')
-    def test_reuse_key_no_dry_run(self, unused_save_successor):
-        test_util.make_lineage(self.config.config_dir, 'sample-renewal.conf')
-        args = ["renew", "--reuse-key"]
-        self._test_renewal_common(True, [], args=args, should_renew=True, reuse_key=True)
-
-    # Should be moved to renewal_test.py
     @mock.patch('sys.stdin')
     def test_noninteractive_renewal_delay(self, stdin):
         stdin.isatty.return_value = False

--- a/certbot/tests/renewal_test.py
+++ b/certbot/tests/renewal_test.py
@@ -161,6 +161,11 @@ class RenewalTest(test_util.ConfigTestCase):
 
         return mock_lineage, mock_get_utility, stdout
 
+    @mock.patch('certbot.storage.RenewableCert.save_successor')
+    def test_reuse_key_no_dry_run(self, unused_save_successor):
+        test_util.make_lineage(self.config.config_dir, 'sample-renewal.conf')
+        args = ["renew", "--reuse-key"]
+        self._test_renewal_common(True, [], args=args, should_renew=True, reuse_key=True)
 
 class RestoreRequiredConfigElementsTest(test_util.ConfigTestCase):
     """Tests for certbot.renewal.restore_required_config_elements."""

--- a/certbot/tests/renewal_test.py
+++ b/certbot/tests/renewal_test.py
@@ -167,6 +167,7 @@ class RenewalTest(test_util.ConfigTestCase):
         args = ["renew", "--reuse-key"]
         self._test_renewal_common(True, [], args=args, should_renew=True, reuse_key=True)
 
+
 class RestoreRequiredConfigElementsTest(test_util.ConfigTestCase):
     """Tests for certbot.renewal.restore_required_config_elements."""
     def setUp(self):


### PR DESCRIPTION
This PR moves the function to correct place in renewal_test.
Haven't found any real need for refactor inside the function...