### PR TITLE
Refactoring of test_certonly_negative_renewal - Fix #4

### DIFF
--- a/certbot/tests/main_test.py
+++ b/certbot/tests/main_test.py
@@ -1059,23 +1059,6 @@ class MainTest(test_util.ConfigTestCase):  # pylint: disable=too-many-public-met
         self.assertTrue('fullchain.pem' in cert_msg)
         self.assertTrue('donate' in get_utility().add_message.call_args[0][0])
 
-    # Should be moved to renewal_test.py
-    @test_util.broken_on_windows
-    @mock.patch('certbot.crypto_util.notAfter')
-    def test_certonly_renewal_triggers(self, unused_notafter):
-        # --dry-run should force renewal
-        _, get_utility, _ = self._test_renewal_common(False, ['--dry-run', '--keep'],
-                                                      log_out="simulating renewal")
-        self.assertEqual(get_utility().add_message.call_count, 1)
-        self.assertTrue('dry run' in get_utility().add_message.call_args[0][0])
-
-        self._test_renewal_common(False, ['--renew-by-default', '-tvv', '--debug'],
-                                  log_out="Auto-renewal forced")
-        self.assertEqual(get_utility().add_message.call_count, 1)
-
-        self._test_renewal_common(False, ['-tvv', '--debug', '--keep'],
-                                  log_out="not yet due", should_renew=False)
-
     def _dump_log(self):
         print("Logs:")
         log_path = os.path.join(self.config.logs_dir, "letsencrypt.log")

--- a/certbot/tests/renewal_test.py
+++ b/certbot/tests/renewal_test.py
@@ -173,7 +173,7 @@ class RenewalTest(test_util.ConfigTestCase): # pylint: disable=too-many-public-m
                     self.assertTrue(log_out in lf.read())
 
         return mock_lineage, mock_get_utility, stdout
-    
+
     @test_util.broken_on_windows
     @mock.patch('certbot.crypto_util.notAfter')
     def test_certonly_renewal_trigger_callcount(self, unused_notafter):

--- a/certbot/tests/renewal_test.py
+++ b/certbot/tests/renewal_test.py
@@ -161,6 +161,22 @@ class RenewalTest(test_util.ConfigTestCase):
 
         return mock_lineage, mock_get_utility, stdout
 
+    @test_util.broken_on_windows
+    @mock.patch('certbot.crypto_util.notAfter')
+    def test_certonly_renewal_triggers(self, unused_notafter):
+        # --dry-run should force renewal
+        _, get_utility, _ = self._test_renewal_common(False, ['--dry-run', '--keep'],
+                                                      log_out="simulating renewal")
+        self.assertEqual(get_utility().add_message.call_count, 1)
+        self.assertTrue('dry run' in get_utility().add_message.call_args[0][0])
+
+        self._test_renewal_common(False, ['--renew-by-default', '-tvv', '--debug'],
+                                  log_out="Auto-renewal forced")
+        self.assertEqual(get_utility().add_message.call_count, 1)
+
+        self._test_renewal_common(False, ['-tvv', '--debug', '--keep'],
+                                  log_out="not yet due", should_renew=False)
+
 
 class RestoreRequiredConfigElementsTest(test_util.ConfigTestCase):
     """Tests for certbot.renewal.restore_required_config_elements."""

--- a/certbot/tests/renewal_test.py
+++ b/certbot/tests/renewal_test.py
@@ -163,16 +163,25 @@ class RenewalTest(test_util.ConfigTestCase):
 
     @test_util.broken_on_windows
     @mock.patch('certbot.crypto_util.notAfter')
-    def test_certonly_renewal_triggers(self, unused_notafter):
+    def test_certonly_renewal_trigger_callcount(self, unused_notafter):
         # --dry-run should force renewal
         _, get_utility, _ = self._test_renewal_common(False, ['--dry-run', '--keep'],
                                                       log_out="simulating renewal")
         self.assertEqual(get_utility().add_message.call_count, 1)
+
+    @test_util.broken_on_windows
+    @mock.patch('certbot.crypto_util.notAfter')
+    def test_certonly_renewal_trigger_dryrun_message(self, unused_notafter):
+        # --dry-run should force renewal
+        _, get_utility, _ = self._test_renewal_common(False, ['--dry-run', '--keep'],
+                                                      log_out="simulating renewal")
+
         self.assertTrue('dry run' in get_utility().add_message.call_args[0][0])
 
-        self._test_renewal_common(False, ['--renew-by-default', '-tvv', '--debug'],
-                                  log_out="Auto-renewal forced")
-        self.assertEqual(get_utility().add_message.call_count, 1)
+    @test_util.broken_on_windows
+    @mock.patch('certbot.crypto_util.notAfter')
+    def test_certonly_negative_renewal(self, unused_notafter):
+        """Testing negatie renewal trigger, should not renew."""
 
         self._test_renewal_common(False, ['-tvv', '--debug', '--keep'],
                                   log_out="not yet due", should_renew=False)

--- a/certbot/tests/renewal_test.py
+++ b/certbot/tests/renewal_test.py
@@ -167,6 +167,8 @@ class RenewalTest(test_util.ConfigTestCase):
         # --dry-run should force renewal
         _, get_utility, _ = self._test_renewal_common(False, ['--dry-run', '--keep'],
                                                       log_out="simulating renewal")
+        self._test_renewal_common(False, ['--renew-by-default', '-tvv', '--debug'],
+                                  log_out="Auto-renewal forced")
         self.assertEqual(get_utility().add_message.call_count, 1)
 
     @test_util.broken_on_windows


### PR DESCRIPTION
* Move test_certonly_renewal_triggers from main_test.py
* Division of test_certonly_renewal_triggers into three tests test_certonly_renewal_trigger_callcount, test_certonly_renewal_trigger_dryrun_message, test_certonly_negative_renewal

Length of the test function names are discussable.