### PR TITLE
Refactor test_renew_with_bad_cli_args - Fix #13

### DIFF
--- a/certbot/tests/main_test.py
+++ b/certbot/tests/main_test.py
@@ -1282,13 +1282,6 @@ class MainTest(test_util.ConfigTestCase):  # pylint: disable=too-many-public-met
                                           args=['renew'], should_renew=False)
 
     # Should be moved to renewal_test.py
-    def test_renew_with_bad_cli_args(self):
-        self._test_renewal_common(True, None, args='renew -d example.com'.split(),
-                                  should_renew=False, error_expected=True)
-        self._test_renewal_common(True, None, args='renew --csr {0}'.format(CSR).split(),
-                                  should_renew=False, error_expected=True)
-
-    # Should be moved to renewal_test.py
     def test_no_renewal_with_hooks(self):
         _, _, stdout = self._test_renewal_common(
             due_for_renewal=False, extra_args=None, should_renew=False,

--- a/certbot/tests/renewal_test.py
+++ b/certbot/tests/renewal_test.py
@@ -15,10 +15,9 @@ from certbot import errors
 from certbot import storage
 from certbot import main
 
-
 import certbot.tests.util as test_util
-CSR = test_util.vector_path('csr_512.der')
 
+CSR = test_util.vector_path('csr_512.der')
 
 
 class RenewalTest(test_util.ConfigTestCase):
@@ -163,10 +162,11 @@ class RenewalTest(test_util.ConfigTestCase):
 
         return mock_lineage, mock_get_utility, stdout
 
-    # Should be moved to renewal_test.py
-    def test_renew_with_bad_cli_args(self):
+    def test_renew_bad_cli_args_with_split(self):
         self._test_renewal_common(True, None, args='renew -d example.com'.split(),
                                   should_renew=False, error_expected=True)
+
+    def test_renew_bad_cli_args_with_format(self):
         self._test_renewal_common(True, None, args='renew --csr {0}'.format(CSR).split(),
                                   should_renew=False, error_expected=True)
 

--- a/certbot/tests/renewal_test.py
+++ b/certbot/tests/renewal_test.py
@@ -17,6 +17,8 @@ from certbot import main
 
 
 import certbot.tests.util as test_util
+CSR = test_util.vector_path('csr_512.der')
+
 
 
 class RenewalTest(test_util.ConfigTestCase):
@@ -160,6 +162,13 @@ class RenewalTest(test_util.ConfigTestCase):
                     self.assertTrue(log_out in lf.read())
 
         return mock_lineage, mock_get_utility, stdout
+
+    # Should be moved to renewal_test.py
+    def test_renew_with_bad_cli_args(self):
+        self._test_renewal_common(True, None, args='renew -d example.com'.split(),
+                                  should_renew=False, error_expected=True)
+        self._test_renewal_common(True, None, args='renew --csr {0}'.format(CSR).split(),
+                                  should_renew=False, error_expected=True)
 
 
 class RestoreRequiredConfigElementsTest(test_util.ConfigTestCase):


### PR DESCRIPTION
* Move test_renew_with_bad_cli_args  from main_test.py to renewal_test.py
* Division of  test_renew_with_bad_cli_args  into two tests. 
