### PR TITLE
Refactor test_renew_verb() - Fix #5

### DIFF
--- a/certbot/tests/main_test.py
+++ b/certbot/tests/main_test.py
@@ -1084,12 +1084,6 @@ class MainTest(test_util.ConfigTestCase):  # pylint: disable=too-many-public-met
                 print(lf.read())
 
     # Should be moved to renewal_test.py
-    def test_renew_verb(self):
-        test_util.make_lineage(self.config.config_dir, 'sample-renewal.conf')
-        args = ["renew", "--dry-run", "-tvv"]
-        self._test_renewal_common(True, [], args=args, should_renew=True)
-
-    # Should be moved to renewal_test.py
     def test_reuse_key(self):
         test_util.make_lineage(self.config.config_dir, 'sample-renewal.conf')
         args = ["renew", "--dry-run", "--reuse-key"]

--- a/certbot/tests/renewal_test.py
+++ b/certbot/tests/renewal_test.py
@@ -161,6 +161,10 @@ class RenewalTest(test_util.ConfigTestCase):
 
         return mock_lineage, mock_get_utility, stdout
 
+    def test_renew_verb(self):
+        test_util.make_lineage(self.config.config_dir, 'sample-renewal.conf')
+        args = ["renew", "--dry-run", "-tvv"]
+        self._test_renewal_common(True, [], args=args, should_renew=True)
 
 class RestoreRequiredConfigElementsTest(test_util.ConfigTestCase):
     """Tests for certbot.renewal.restore_required_config_elements."""


### PR DESCRIPTION
This PR moves the simple test test_renew_verb() from main_test.py to renewal_test.py, where it is more suited to be located.