### PR TITLE
Refactor test_renew_hook_validaton() - fix #16

### DIFF
--- a/certbot/tests/main_test.py
+++ b/certbot/tests/main_test.py
@@ -1151,13 +1151,6 @@ class MainTest(test_util.ConfigTestCase):  # pylint: disable=too-many-public-met
         self.assertEqual("", out)
 
     # Should be moved to renewal_test.py
-    def test_renew_hook_validation(self):
-        test_util.make_lineage(self.config.config_dir, 'sample-renewal.conf')
-        args = ["renew", "--dry-run", "--post-hook=no-such-command"]
-        self._test_renewal_common(True, [], args=args, should_renew=False,
-                                  error_expected=True)
-
-    # Should be moved to renewal_test.py
     def test_renew_no_hook_validation(self):
         test_util.make_lineage(self.config.config_dir, 'sample-renewal.conf')
         args = ["renew", "--dry-run", "--post-hook=no-such-command",

--- a/certbot/tests/renewal_test.py
+++ b/certbot/tests/renewal_test.py
@@ -161,6 +161,11 @@ class RenewalTest(test_util.ConfigTestCase):
 
         return mock_lineage, mock_get_utility, stdout
 
+    def test_renew_hook_validation(self):
+        test_util.make_lineage(self.config.config_dir, 'sample-renewal.conf')
+        args = ["renew", "--dry-run", "--post-hook=no-such-command"]
+        self._test_renewal_common(True, [], args=args, should_renew=False,
+                                  error_expected=True)
 
 class RestoreRequiredConfigElementsTest(test_util.ConfigTestCase):
     """Tests for certbot.renewal.restore_required_config_elements."""

--- a/certbot/tests/renewal_test.py
+++ b/certbot/tests/renewal_test.py
@@ -173,7 +173,7 @@ class RenewalTest(test_util.ConfigTestCase):
         args = ["renew", "--dry-run", "--post-hook=no-such-command"]
         self._test_renewal_common(True, [], args=args, should_renew=False,
                                   error_expected=True)
-        
+
     def test_renew_bad_cli_args_with_split(self):
         self._test_renewal_common(True, None, args='renew -d example.com'.split(),
                                   should_renew=False, error_expected=True)


### PR DESCRIPTION
This PR moves the simple test test_renew_hook_validation from main_test.py to renewal_test.py, where it is more suited to be located. 