### PR TITLE
Refactor test_renew_no_hook_validaton() - fix #17

### DIFF
--- a/certbot/tests/main_test.py
+++ b/certbot/tests/main_test.py
@@ -1158,15 +1158,6 @@ class MainTest(test_util.ConfigTestCase):  # pylint: disable=too-many-public-met
                                   error_expected=True)
 
     # Should be moved to renewal_test.py
-    def test_renew_no_hook_validation(self):
-        test_util.make_lineage(self.config.config_dir, 'sample-renewal.conf')
-        args = ["renew", "--dry-run", "--post-hook=no-such-command",
-                "--disable-hook-validation"]
-        with mock.patch("certbot.hooks.post_hook"):
-            self._test_renewal_common(True, [], args=args, should_renew=True,
-                                      error_expected=False)
-
-    # Should be moved to renewal_test.py
     def test_renew_verb_empty_config(self):
         rd = os.path.join(self.config.config_dir, 'renewal')
         if not os.path.exists(rd):

--- a/certbot/tests/renewal_test.py
+++ b/certbot/tests/renewal_test.py
@@ -161,6 +161,13 @@ class RenewalTest(test_util.ConfigTestCase):
 
         return mock_lineage, mock_get_utility, stdout
 
+    @mock.patch('certbot.hooks.post_hook')
+    def test_renew_no_hook_validation(self, unused_post_hook):
+        test_util.make_lineage(self.config.config_dir, 'sample-renewal.conf')
+        args = ["renew", "--dry-run", "--post-hook=no-such-command",
+                "--disable-hook-validation"]
+        self._test_renewal_common(True, [], args=args, should_renew=True,
+                                      error_expected=False)
 
 class RestoreRequiredConfigElementsTest(test_util.ConfigTestCase):
     """Tests for certbot.renewal.restore_required_config_elements."""


### PR DESCRIPTION
This PR moves the simple test test_renew_no_hook_validation from main_test.py to renewal_test.py, where it is more suited to be located. Also sets mock.patch before test, so it follows similiar tests standard.
