### PR TITLE
Refactor test_renew_with_certname

### DIFF
--- a/certbot/tests/main_test.py
+++ b/certbot/tests/main_test.py
@@ -1177,12 +1177,6 @@ class MainTest(test_util.ConfigTestCase):  # pylint: disable=too-many-public-met
         self._test_renewal_common(False, [], args=args, should_renew=False, error_expected=True)
 
     # Should be moved to renewal_test.py
-    def test_renew_with_certname(self):
-        test_util.make_lineage(self.config.config_dir, 'sample-renewal.conf')
-        self._test_renewal_common(True, [], should_renew=True,
-            args=['renew', '--dry-run', '--cert-name', 'sample-renewal'])
-
-    # Should be moved to renewal_test.py
     def test_renew_with_bad_certname(self):
         self._test_renewal_common(True, [], should_renew=False,
             args=['renew', '--dry-run', '--cert-name', 'sample-renewal'],

--- a/certbot/tests/renewal_test.py
+++ b/certbot/tests/renewal_test.py
@@ -161,6 +161,11 @@ class RenewalTest(test_util.ConfigTestCase):
 
         return mock_lineage, mock_get_utility, stdout
 
+    def test_renew_with_certname(self):
+        test_util.make_lineage(self.config.config_dir, 'sample-renewal.conf')
+        self._test_renewal_common(True, [], should_renew=True,
+                                  args=['renew', '--dry-run', '--cert-name', 'sample-renewal'])
+
 
 class RestoreRequiredConfigElementsTest(test_util.ConfigTestCase):
     """Tests for certbot.renewal.restore_required_config_elements."""


### PR DESCRIPTION
Moved the simple test function test_renew_with_certname() from main_test.py to renewal_test.py, a more suitable location. 