### PR TITLE
Refactor test_renew_with_bad_certname - Fix #21

### DIFF
--- a/certbot/tests/main_test.py
+++ b/certbot/tests/main_test.py
@@ -1182,12 +1182,6 @@ class MainTest(test_util.ConfigTestCase):  # pylint: disable=too-many-public-met
         self._test_renewal_common(True, [], should_renew=True,
             args=['renew', '--dry-run', '--cert-name', 'sample-renewal'])
 
-    # Should be moved to renewal_test.py
-    def test_renew_with_bad_certname(self):
-        self._test_renewal_common(True, [], should_renew=False,
-            args=['renew', '--dry-run', '--cert-name', 'sample-renewal'],
-            error_expected=True)
-
     def _make_dummy_renewal_config(self):
         renewer_configs_dir = os.path.join(self.config.config_dir, 'renewal')
         os.makedirs(renewer_configs_dir)

--- a/certbot/tests/renewal_test.py
+++ b/certbot/tests/renewal_test.py
@@ -161,6 +161,11 @@ class RenewalTest(test_util.ConfigTestCase):
 
         return mock_lineage, mock_get_utility, stdout
 
+    def test_renew_with_bad_certname(self):
+        self._test_renewal_common(True, [], should_renew=False,
+                                  args=['renew', '--dry-run', '--cert-name', 'sample-renewal'],
+                                  error_expected=True)
+
 
 class RestoreRequiredConfigElementsTest(test_util.ConfigTestCase):
     """Tests for certbot.renewal.restore_required_config_elements."""


### PR DESCRIPTION
Moved the simple test function test_renew_with_bad_certname() from main_test.py to renewal_test.py, a more suitable location.
