### PR TITLE
Add test_renew_verb_empty_config to renewal_test.py - Fix #31

### DIFF
--- a/certbot/tests/renewal_test.py
+++ b/certbot/tests/renewal_test.py
@@ -213,6 +213,15 @@ class RenewalTest(test_util.ConfigTestCase):
         self._test_renewal_common(True, None, args='renew --csr {0}'.format(CSR).split(),
                                   should_renew=False, error_expected=True)
 
+    def test_renew_verb_empty_config(self):
+        rd = os.path.join(self.config.config_dir, 'renewal')
+        if not os.path.exists(rd):
+            os.makedirs(rd)
+        with open(os.path.join(rd, 'empty.conf'), 'w'):
+            pass  # leave the file empty
+        args = ["renew", "--dry-run", "-tvv"]
+        self._test_renewal_common(False, [], args=args, should_renew=False, error_expected=True)
+
     @mock.patch('sys.stdin')
     def test_interactive_no_renewal_delay(self, stdin):
         stdin.isatty.return_value = True


### PR DESCRIPTION
The test function test_renew_verb_empty_config was removed by mistake from renewal_test.py when resolving a merge conflict. This PR adds the function back to renewal_test.py.