### PR TITLE
Refactoring of tests for certbot/renewal (Patch demonstation)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ branches:
     - /^\d+\.\d+\.x$/
     - /^test-.*$/
     - refactor
-    - /^issue/\d+
+    - /^issue[\/].*
 
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ branches:
     - /^\d+\.\d+\.x$/
     - /^test-.*$/
     - refactor
-    - /^issue[\/].*
+    - /^issue\/.*$/
 
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ branches:
     - master
     - /^\d+\.\d+\.x$/
     - /^test-.*$/
+    - refactor
 
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,54 +18,55 @@ branches:
     - /^\d+\.\d+\.x$/
     - /^test-.*$/
     - refactor
+    - /^issue/\d+
 
 matrix:
   include:
     # These environments are always executed
-    - python: "2.7"
-      env: BOULDER_INTEGRATION=v1 INTEGRATION_TEST=all TOXENV=py27_install
-      sudo: required
-      services: docker
-    - python: "2.7"
-      env: BOULDER_INTEGRATION=v2 INTEGRATION_TEST=all TOXENV=py27_install
-      sudo: required
-      services: docker
-    - python: "2.7"
-      env: TOXENV=py27-cover FYI="py27 tests + code coverage"
-    - sudo: required
-      env: TOXENV=nginx_compat
-      services: docker
-      before_install:
-      addons:
+    # - python: "2.7"
+    #   env: BOULDER_INTEGRATION=v1 INTEGRATION_TEST=all TOXENV=py27_install
+    #   sudo: required
+    #   services: docker
+    # - python: "2.7"
+    #   env: BOULDER_INTEGRATION=v2 INTEGRATION_TEST=all TOXENV=py27_install
+    #   sudo: required
+    #   services: docker
+    # - python: "2.7"
+    #   env: TOXENV=py27-cover FYI="py27 tests + code coverage"
+    # - sudo: required
+    #   env: TOXENV=nginx_compat
+    #   services: docker
+    #   before_install:
+    #   addons:
     - python: "2.7"
       env: TOXENV=lint
-    - python: "3.4"
-      env: TOXENV=mypy
-    - python: "3.5"
-      env: TOXENV=mypy
+    # - python: "3.4"
+    #   env: TOXENV=mypy
+    # - python: "3.5"
+    #   env: TOXENV=mypy
     - python: "2.7"
       env: TOXENV='py27-{acme,apache,certbot,dns,nginx,postfix}-oldest'
       sudo: required
       services: docker
-    - python: "3.4"
-      env: TOXENV=py34
-      sudo: required
-      services: docker
-    - python: "3.7"
-      dist: xenial
-      env: TOXENV=py37
-      sudo: required
-      services: docker
-    - sudo: required
-      env: TOXENV=apache_compat
-      services: docker
-      before_install:
-      addons:
-    - sudo: required
-      env: TOXENV=le_auto_trusty
-      services: docker
-      before_install:
-      addons:
+    # - python: "3.4"
+    #   env: TOXENV=py34
+    #   sudo: required
+    #   services: docker
+    # - python: "3.7"
+    #   dist: xenial
+    #   env: TOXENV=py37
+    #   sudo: required
+    #   services: docker
+    # - sudo: required
+    #   env: TOXENV=apache_compat
+    #   services: docker
+    #   before_install:
+    #   addons:
+    # - sudo: required
+    #   env: TOXENV=le_auto_trusty
+    #   services: docker
+    #   before_install:
+    #   addons:
     - python: "2.7"
       env: TOXENV=apacheconftest-with-pebble
       sudo: required
@@ -76,10 +77,10 @@ matrix:
     # These environments are executed on cron events and commits to tested
     # branches other than master. Which branches are tested is controlled by
     # the "branches" section earlier in this file.
-    - python: "3.7"
-      dist: xenial
-      env: TOXENV=py37 CERTBOT_NO_PIN=1
-      if: type = cron OR (type = push AND branch != master)
+    # - python: "3.7"
+    #   dist: xenial
+    #   env: TOXENV=py37 CERTBOT_NO_PIN=1
+    #   if: type = cron OR (type = push AND branch != master)
     - python: "2.7"
       env: BOULDER_INTEGRATION=v1 INTEGRATION_TEST=certbot TOXENV=py27-certbot-oldest
       sudo: required
@@ -90,96 +91,96 @@ matrix:
       sudo: required
       services: docker
       if: type = cron OR (type = push AND branch != master)
-    - python: "2.7"
-      env: BOULDER_INTEGRATION=v1 INTEGRATION_TEST=nginx TOXENV=py27-nginx-oldest
-      sudo: required
-      services: docker
-      if: type = cron OR (type = push AND branch != master)
-    - python: "2.7"
-      env: BOULDER_INTEGRATION=v2 INTEGRATION_TEST=nginx TOXENV=py27-nginx-oldest
-      sudo: required
-      services: docker
-      if: type = cron OR (type = push AND branch != master)
-    - python: "3.4"
-      env: TOXENV=py34 BOULDER_INTEGRATION=v1
-      sudo: required
-      services: docker
-      if: type = cron OR (type = push AND branch != master)
-    - python: "3.4"
-      env: TOXENV=py34 BOULDER_INTEGRATION=v2
-      sudo: required
-      services: docker
-      if: type = cron OR (type = push AND branch != master)
-    - python: "3.5"
-      env: TOXENV=py35 BOULDER_INTEGRATION=v1
-      sudo: required
-      services: docker
-      if: type = cron OR (type = push AND branch != master)
-    - python: "3.5"
-      env: TOXENV=py35 BOULDER_INTEGRATION=v2
-      sudo: required
-      services: docker
-      if: type = cron OR (type = push AND branch != master)
-    - python: "3.6"
-      env: TOXENV=py36 BOULDER_INTEGRATION=v1
-      sudo: required
-      services: docker
-      if: type = cron OR (type = push AND branch != master)
-    - python: "3.6"
-      env: TOXENV=py36 BOULDER_INTEGRATION=v2
-      sudo: required
-      services: docker
-      if: type = cron OR (type = push AND branch != master)
-    - python: "3.7"
-      dist: xenial
-      env: TOXENV=py37 BOULDER_INTEGRATION=v1
-      sudo: required
-      services: docker
-      if: type = cron OR (type = push AND branch != master)
-    - python: "3.7"
-      dist: xenial
-      env: TOXENV=py37 BOULDER_INTEGRATION=v2
-      sudo: required
-      services: docker
-      if: type = cron OR (type = push AND branch != master)
-    - sudo: required
-      env: TOXENV=le_auto_xenial
-      services: docker
-      if: type = cron OR (type = push AND branch != master)
-    - sudo: required
-      env: TOXENV=le_auto_jessie
-      services: docker
-      if: type = cron OR (type = push AND branch != master)
-    - sudo: required
-      env: TOXENV=le_auto_centos6
-      services: docker
-      if: type = cron OR (type = push AND branch != master)
-    - sudo: required
-      env: TOXENV=docker_dev
-      services: docker
-      addons:
-        apt:
-          packages:  # don't install nginx and apache
-            - libaugeas0
-      if: type = cron OR (type = push AND branch != master)
-    - language: generic
-      env: TOXENV=py27
-      os: osx
-      addons:
-        homebrew:
-          packages:
-            - augeas
-            - python2
-      if: type = cron OR (type = push AND branch != master)
-    - language: generic
-      env: TOXENV=py3
-      os: osx
-      addons:
-        homebrew:
-          packages:
-            - augeas
-            - python3
-      if: type = cron OR (type = push AND branch != master)
+    # - python: "2.7"
+    #   env: BOULDER_INTEGRATION=v1 INTEGRATION_TEST=nginx TOXENV=py27-nginx-oldest
+    #   sudo: required
+    #   services: docker
+    #   if: type = cron OR (type = push AND branch != master)
+    # - python: "2.7"
+    #   env: BOULDER_INTEGRATION=v2 INTEGRATION_TEST=nginx TOXENV=py27-nginx-oldest
+    #   sudo: required
+    #   services: docker
+    #   if: type = cron OR (type = push AND branch != master)
+    # - python: "3.4"
+    #   env: TOXENV=py34 BOULDER_INTEGRATION=v1
+    #   sudo: required
+    #   services: docker
+    #   if: type = cron OR (type = push AND branch != master)
+    # - python: "3.4"
+    #   env: TOXENV=py34 BOULDER_INTEGRATION=v2
+    #   sudo: required
+    #   services: docker
+    #   if: type = cron OR (type = push AND branch != master)
+    # - python: "3.5"
+    #   env: TOXENV=py35 BOULDER_INTEGRATION=v1
+    #   sudo: required
+    #   services: docker
+    #   if: type = cron OR (type = push AND branch != master)
+    # - python: "3.5"
+    #   env: TOXENV=py35 BOULDER_INTEGRATION=v2
+    #   sudo: required
+    #   services: docker
+    #   if: type = cron OR (type = push AND branch != master)
+    # - python: "3.6"
+    #   env: TOXENV=py36 BOULDER_INTEGRATION=v1
+    #   sudo: required
+    #   services: docker
+    #   if: type = cron OR (type = push AND branch != master)
+    # - python: "3.6"
+    #   env: TOXENV=py36 BOULDER_INTEGRATION=v2
+    #   sudo: required
+    #   services: docker
+    #   if: type = cron OR (type = push AND branch != master)
+    # - python: "3.7"
+    #   dist: xenial
+    #   env: TOXENV=py37 BOULDER_INTEGRATION=v1
+    #   sudo: required
+    #   services: docker
+    #   if: type = cron OR (type = push AND branch != master)
+    # - python: "3.7"
+    #   dist: xenial
+    #   env: TOXENV=py37 BOULDER_INTEGRATION=v2
+    #   sudo: required
+    #   services: docker
+    #   if: type = cron OR (type = push AND branch != master)
+    # - sudo: required
+    #   env: TOXENV=le_auto_xenial
+    #   services: docker
+    #   if: type = cron OR (type = push AND branch != master)
+    # - sudo: required
+    #   env: TOXENV=le_auto_jessie
+    #   services: docker
+    #   if: type = cron OR (type = push AND branch != master)
+    # - sudo: required
+    #   env: TOXENV=le_auto_centos6
+    #   services: docker
+    #   if: type = cron OR (type = push AND branch != master)
+    # - sudo: required
+    #   env: TOXENV=docker_dev
+    #   services: docker
+    #   addons:
+    #     apt:
+    #       packages:  # don't install nginx and apache
+    #         - libaugeas0
+    #   if: type = cron OR (type = push AND branch != master)
+    # - language: generic
+    #   env: TOXENV=py27
+    #   os: osx
+    #   addons:
+    #     homebrew:
+    #       packages:
+    #         - augeas
+    #         - python2
+    #   if: type = cron OR (type = push AND branch != master)
+    # - language: generic
+    #   env: TOXENV=py3
+    #   os: osx
+    #   addons:
+    #     homebrew:
+    #       packages:
+    #         - augeas
+    #         - python3
+    #   if: type = cron OR (type = push AND branch != master)
 
 # container-based infrastructure
 sudo: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ Certbot adheres to [Semantic Versioning](https://semver.org/).
   warnings described at https://github.com/certbot/josepy/issues/13.
 * Apache plugin now respects CERTBOT_DOCS environment variable when adding
   command line defaults.
+* Tests for renewal are refactored according to:
+  https://github.com/certbot/certbot/issues/4069. The tests are moved to correct
+  test file and refactored into smaller test cases when possible.
 
 ### Fixed
 

--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,38 @@
 .. This file contains a series of comments that are used to include sections of this README in other files. Do not modify these comments unless you know what you are doing. tag:intro-begin
+Patch
+------------
+Look at pull-request #40 to see a demonstration of our patch.
+
+Statement of contributions
+------------
+Alzahraa Salman:
+Refactored:
+test_renew_verb_empty_config, test_renew_with_bad_certname, test_renew_with_certname, test_renew_with_bad_cli_args, test_reuse_key.
+Configuration of project and written report.
+
+Helena Alinder:
+Refactored:
+test_renew_no_hook_validation, test_renew_hook_validation, test_renew_verb.
+Configuration and written report.
+
+Jesper Larsson:
+Refactored:
+test_no_renewal_with_hooks, test_renew_skips_recent_certs, test_certonly_renewal.
+Initial configuration.
+
+Marcus Granström:
+Refactored: 
+test_noninteractive_renewal_delay, test_interactive_no_renewal_delay, test_renew_verb_empty_config, test_quiet_renew, test_reuse_key_no_dry_run.
+Configuration. Moved test_renew_common and updated CHANGELOG.
+
+Veronica Hage:
+Refactored:
+test_renew_obtain_cert_error,
+test_certonly_renewal_triggers.
+Configuration.
+
+Beginning of certbots official README
+------------
 
 Certbot is part of EFF’s effort to encrypt the entire Internet. Secure communication over the Web relies on HTTPS, which requires the use of a digital certificate that lets browsers verify the identity of web servers (e.g., is that really google.com?). Web servers obtain their certificates from trusted third parties called certificate authorities (CAs). Certbot is an easy-to-use client that fetches a certificate from Let’s Encrypt—an open certificate authority launched by the EFF, Mozilla, and others—and deploys it to a web server.
 

--- a/certbot/tests/main_test.py
+++ b/certbot/tests/main_test.py
@@ -1094,22 +1094,6 @@ class MainTest(test_util.ConfigTestCase):  # pylint: disable=too-many-public-met
         self.assertTrue('No renewals were attempted.' in stdout.getvalue())
         self.assertTrue('The following certs are not due for renewal yet:' in stdout.getvalue())
 
-    # Should be moved to renewal_test.py
-    @test_util.broken_on_windows
-    def test_quiet_renew(self):
-        test_util.make_lineage(self.config.config_dir, 'sample-renewal.conf')
-        args = ["renew", "--dry-run"]
-        _, _, stdout = self._test_renewal_common(True, [], args=args, should_renew=True)
-        out = stdout.getvalue()
-        self.assertTrue("renew" in out)
-
-        args = ["renew", "--dry-run", "-q"]
-        _, _, stdout = self._test_renewal_common(True, [], args=args,
-                                                 should_renew=True, quiet_mode=True)
-        out = stdout.getvalue()
-        self.assertEqual("", out)
-
-
     def _make_dummy_renewal_config(self):
         renewer_configs_dir = os.path.join(self.config.config_dir, 'renewal')
         os.makedirs(renewer_configs_dir)

--- a/certbot/tests/main_test.py
+++ b/certbot/tests/main_test.py
@@ -1049,17 +1049,6 @@ class MainTest(test_util.ConfigTestCase):  # pylint: disable=too-many-public-met
         return mock_lineage, mock_get_utility, stdout
 
     # Should be moved to renewal_test.py
-    @mock.patch('certbot.crypto_util.notAfter')
-    def test_certonly_renewal(self, unused_notafter):
-        lineage, get_utility, _ = self._test_renewal_common(True, [])
-        self.assertEqual(lineage.save_successor.call_count, 1)
-        lineage.update_all_links_to.assert_called_once_with(
-            lineage.latest_common_version())
-        cert_msg = get_utility().add_message.call_args_list[0][0][0]
-        self.assertTrue('fullchain.pem' in cert_msg)
-        self.assertTrue('donate' in get_utility().add_message.call_args[0][0])
-
-    # Should be moved to renewal_test.py
     @test_util.broken_on_windows
     @mock.patch('certbot.crypto_util.notAfter')
     def test_certonly_renewal_triggers(self, unused_notafter):

--- a/certbot/tests/main_test.py
+++ b/certbot/tests/main_test.py
@@ -7,7 +7,6 @@ import itertools
 import mock
 import os
 import shutil
-import traceback
 import unittest
 import datetime
 import pytz
@@ -967,83 +966,6 @@ class MainTest(test_util.ConfigTestCase):  # pylint: disable=too-many-public-met
         mock_client.obtain_and_enroll_certificate.return_value = False
         self.assertRaises(errors.Error,
                           self._certonly_new_request_common, mock_client)
-
-    # Should be moved to renewal_test.py
-    # Test commit
-    def _test_renewal_common(self, due_for_renewal, extra_args, log_out=None,
-                             args=None, should_renew=True, error_expected=False,
-                             quiet_mode=False, expiry_date=datetime.datetime.now(),
-                             reuse_key=False):
-        # pylint: disable=too-many-locals,too-many-arguments,too-many-branches
-        cert_path = test_util.vector_path('cert_512.pem')
-        chain_path = os.path.normpath(os.path.join(self.config.config_dir,
-                                                   'live/foo.bar/fullchain.pem'))
-        mock_lineage = mock.MagicMock(cert=cert_path, fullchain=chain_path,
-                                      cert_path=cert_path, fullchain_path=chain_path)
-        mock_lineage.should_autorenew.return_value = due_for_renewal
-        mock_lineage.has_pending_deployment.return_value = False
-        mock_lineage.names.return_value = ['isnot.org']
-        mock_certr = mock.MagicMock()
-        mock_key = mock.MagicMock(pem='pem_key')
-        mock_client = mock.MagicMock()
-        stdout = six.StringIO()
-        mock_client.obtain_certificate.return_value = (mock_certr, 'chain',
-                                                       mock_key, 'csr')
-
-        def write_msg(message, *args, **kwargs):  # pylint: disable=unused-argument
-            """Write message to stdout."""
-            stdout.write(message)
-
-        try:
-            with mock.patch('certbot.cert_manager.find_duplicative_certs') as mock_fdc:
-                mock_fdc.return_value = (mock_lineage, None)
-                with mock.patch('certbot.main._init_le_client') as mock_init:
-                    mock_init.return_value = mock_client
-                    with test_util.patch_get_utility() as mock_get_utility:
-                        if not quiet_mode:
-                            mock_get_utility().notification.side_effect = write_msg
-                        with mock.patch('certbot.main.renewal.OpenSSL') as mock_ssl:
-                            mock_latest = mock.MagicMock()
-                            mock_latest.get_issuer.return_value = "Fake fake"
-                            mock_ssl.crypto.load_certificate.return_value = mock_latest
-                            with mock.patch('certbot.main.renewal.crypto_util') as mock_crypto_util:
-                                mock_crypto_util.notAfter.return_value = expiry_date
-                                if not args:
-                                    args = ['-d', 'isnot.org', '-a', 'standalone', 'certonly']
-                                if extra_args:
-                                    args += extra_args
-                                try:
-                                    ret, stdout, _, _ = self._call(args, stdout)
-                                    if ret:
-                                        print("Returned", ret)
-                                        raise AssertionError(ret)
-                                    assert not error_expected, "renewal should have errored"
-                                except: # pylint: disable=bare-except
-                                    if not error_expected:
-                                        raise AssertionError(
-                                            "Unexpected renewal error:\n" +
-                                            traceback.format_exc())
-
-            if should_renew:
-                if reuse_key:
-                    # The location of the previous live privkey.pem is passed
-                    # to obtain_certificate
-                    mock_client.obtain_certificate.assert_called_once_with(['isnot.org'],
-                        os.path.normpath(os.path.join(
-                            self.config.config_dir, "live/sample-renewal/privkey.pem")))
-                else:
-                    mock_client.obtain_certificate.assert_called_once_with(['isnot.org'], None)
-            else:
-                self.assertEqual(mock_client.obtain_certificate.call_count, 0)
-        except:
-            self._dump_log()
-            raise
-        finally:
-            if log_out:
-                with open(os.path.join(self.config.logs_dir, "letsencrypt.log")) as lf:
-                    self.assertTrue(log_out in lf.read())
-
-        return mock_lineage, mock_get_utility, stdout
 
     def _dump_log(self):
         print("Logs:")

--- a/certbot/tests/main_test.py
+++ b/certbot/tests/main_test.py
@@ -1045,17 +1045,6 @@ class MainTest(test_util.ConfigTestCase):  # pylint: disable=too-many-public-met
 
         return mock_lineage, mock_get_utility, stdout
 
-    # Should be moved to renewal_test.py
-    @mock.patch('certbot.crypto_util.notAfter')
-    def test_certonly_renewal(self, unused_notafter):
-        lineage, get_utility, _ = self._test_renewal_common(True, [])
-        self.assertEqual(lineage.save_successor.call_count, 1)
-        lineage.update_all_links_to.assert_called_once_with(
-            lineage.latest_common_version())
-        cert_msg = get_utility().add_message.call_args_list[0][0][0]
-        self.assertTrue('fullchain.pem' in cert_msg)
-        self.assertTrue('donate' in get_utility().add_message.call_args[0][0])
-
     def _dump_log(self):
         print("Logs:")
         log_path = os.path.join(self.config.logs_dir, "letsencrypt.log")

--- a/certbot/tests/main_test.py
+++ b/certbot/tests/main_test.py
@@ -1069,26 +1069,6 @@ class MainTest(test_util.ConfigTestCase):  # pylint: disable=too-many-public-met
             with open(log_path) as lf:
                 print(lf.read())
 
-    def _make_dummy_renewal_config(self):
-        renewer_configs_dir = os.path.join(self.config.config_dir, 'renewal')
-        os.makedirs(renewer_configs_dir)
-        with open(os.path.join(renewer_configs_dir, 'test.conf'), 'w') as f:
-            f.write("My contents don't matter")
-
-    # Should be moved to renewal_test.py
-    def test_renew_obtain_cert_error(self):
-        self._make_dummy_renewal_config()
-        with mock.patch('certbot.storage.RenewableCert') as mock_rc:
-            mock_lineage = mock.MagicMock()
-            mock_lineage.fullchain = "somewhere/fullchain.pem"
-            mock_rc.return_value = mock_lineage
-            mock_lineage.configuration = {
-                'renewalparams': {'authenticator': 'webroot'}}
-            with mock.patch('certbot.main.renew_cert') as mock_renew_cert:
-                mock_renew_cert.side_effect = Exception
-                self._test_renewal_common(True, None, error_expected=True,
-                                          args=['renew'], should_renew=False)
-
     @test_util.patch_get_utility()
     @mock.patch('certbot.main._find_lineage_for_domains_and_certname')
     @mock.patch('certbot.main._init_le_client')

--- a/certbot/tests/main_test.py
+++ b/certbot/tests/main_test.py
@@ -1089,11 +1089,6 @@ class MainTest(test_util.ConfigTestCase):  # pylint: disable=too-many-public-met
         args = ["renew", "--dry-run", "-tvv"]
         self._test_renewal_common(True, [], args=args, should_renew=True)
 
-    # Should be moved to renewal_test.py
-    def test_reuse_key(self):
-        test_util.make_lineage(self.config.config_dir, 'sample-renewal.conf')
-        args = ["renew", "--dry-run", "--reuse-key"]
-        self._test_renewal_common(True, [], args=args, should_renew=True, reuse_key=True)
 
     # Should be moved to renewal_test.py
     @mock.patch('certbot.storage.RenewableCert.save_successor')

--- a/certbot/tests/main_test.py
+++ b/certbot/tests/main_test.py
@@ -971,7 +971,7 @@ class MainTest(test_util.ConfigTestCase):  # pylint: disable=too-many-public-met
         self.assertRaises(errors.Error,
                           self._certonly_new_request_common, mock_client)
 
-    # Should be moved to renewal_test.py 
+    # Should be moved to renewal_test.py
     # Test commit
     def _test_renewal_common(self, due_for_renewal, extra_args, log_out=None,
                              args=None, should_renew=True, error_expected=False,

--- a/certbot/tests/main_test.py
+++ b/certbot/tests/main_test.py
@@ -1146,13 +1146,6 @@ class MainTest(test_util.ConfigTestCase):  # pylint: disable=too-many-public-met
         self.assertEqual("", out)
 
     # Should be moved to renewal_test.py
-    def test_renew_hook_validation(self):
-        test_util.make_lineage(self.config.config_dir, 'sample-renewal.conf')
-        args = ["renew", "--dry-run", "--post-hook=no-such-command"]
-        self._test_renewal_common(True, [], args=args, should_renew=False,
-                                  error_expected=True)
-
-    # Should be moved to renewal_test.py
     def test_renew_no_hook_validation(self):
         test_util.make_lineage(self.config.config_dir, 'sample-renewal.conf')
         args = ["renew", "--dry-run", "--post-hook=no-such-command",

--- a/certbot/tests/main_test.py
+++ b/certbot/tests/main_test.py
@@ -13,7 +13,6 @@ import unittest
 import datetime
 import pytz
 import tempfile
-import sys
 
 import josepy as jose
 import six
@@ -1164,15 +1163,6 @@ class MainTest(test_util.ConfigTestCase):  # pylint: disable=too-many-public-met
                 mock_renew_cert.side_effect = Exception
                 self._test_renewal_common(True, None, error_expected=True,
                                           args=['renew'], should_renew=False)
-
-    # Should be moved to renewal_test.py
-    def test_no_renewal_with_hooks(self):
-        _, _, stdout = self._test_renewal_common(
-            due_for_renewal=False, extra_args=None, should_renew=False,
-            args=['renew', '--post-hook',
-                  '{0} -c "from __future__ import print_function; print(\'hello world\');"'
-                  .format(sys.executable)])
-        self.assertTrue('No hooks were run.' in stdout.getvalue())
 
     @test_util.patch_get_utility()
     @mock.patch('certbot.main._find_lineage_for_domains_and_certname')

--- a/certbot/tests/main_test.py
+++ b/certbot/tests/main_test.py
@@ -1132,12 +1132,6 @@ class MainTest(test_util.ConfigTestCase):  # pylint: disable=too-many-public-met
         self.assertEqual("", out)
 
 
-    # Should be moved to renewal_test.py
-    def test_renew_with_bad_certname(self):
-        self._test_renewal_common(True, [], should_renew=False,
-            args=['renew', '--dry-run', '--cert-name', 'sample-renewal'],
-            error_expected=True)
-
     def _make_dummy_renewal_config(self):
         renewer_configs_dir = os.path.join(self.config.config_dir, 'renewal')
         os.makedirs(renewer_configs_dir)

--- a/certbot/tests/main_test.py
+++ b/certbot/tests/main_test.py
@@ -971,7 +971,8 @@ class MainTest(test_util.ConfigTestCase):  # pylint: disable=too-many-public-met
         self.assertRaises(errors.Error,
                           self._certonly_new_request_common, mock_client)
 
-    # Should be moved to renewal_test.py
+    # Should be moved to renewal_test.py 
+    # Test commit
     def _test_renewal_common(self, due_for_renewal, extra_args, log_out=None,
                              args=None, should_renew=True, error_expected=False,
                              quiet_mode=False, expiry_date=datetime.datetime.now(),

--- a/certbot/tests/main_test.py
+++ b/certbot/tests/main_test.py
@@ -971,6 +971,7 @@ class MainTest(test_util.ConfigTestCase):  # pylint: disable=too-many-public-met
         self.assertRaises(errors.Error,
                           self._certonly_new_request_common, mock_client)
 
+    # Should be moved to renewal_test.py
     def _test_renewal_common(self, due_for_renewal, extra_args, log_out=None,
                              args=None, should_renew=True, error_expected=False,
                              quiet_mode=False, expiry_date=datetime.datetime.now(),
@@ -1046,6 +1047,7 @@ class MainTest(test_util.ConfigTestCase):  # pylint: disable=too-many-public-met
 
         return mock_lineage, mock_get_utility, stdout
 
+    # Should be moved to renewal_test.py
     @mock.patch('certbot.crypto_util.notAfter')
     def test_certonly_renewal(self, unused_notafter):
         lineage, get_utility, _ = self._test_renewal_common(True, [])
@@ -1056,6 +1058,7 @@ class MainTest(test_util.ConfigTestCase):  # pylint: disable=too-many-public-met
         self.assertTrue('fullchain.pem' in cert_msg)
         self.assertTrue('donate' in get_utility().add_message.call_args[0][0])
 
+    # Should be moved to renewal_test.py
     @test_util.broken_on_windows
     @mock.patch('certbot.crypto_util.notAfter')
     def test_certonly_renewal_triggers(self, unused_notafter):
@@ -1079,22 +1082,26 @@ class MainTest(test_util.ConfigTestCase):  # pylint: disable=too-many-public-met
             with open(log_path) as lf:
                 print(lf.read())
 
+    # Should be moved to renewal_test.py
     def test_renew_verb(self):
         test_util.make_lineage(self.config.config_dir, 'sample-renewal.conf')
         args = ["renew", "--dry-run", "-tvv"]
         self._test_renewal_common(True, [], args=args, should_renew=True)
 
+    # Should be moved to renewal_test.py
     def test_reuse_key(self):
         test_util.make_lineage(self.config.config_dir, 'sample-renewal.conf')
         args = ["renew", "--dry-run", "--reuse-key"]
         self._test_renewal_common(True, [], args=args, should_renew=True, reuse_key=True)
 
+    # Should be moved to renewal_test.py
     @mock.patch('certbot.storage.RenewableCert.save_successor')
     def test_reuse_key_no_dry_run(self, unused_save_successor):
         test_util.make_lineage(self.config.config_dir, 'sample-renewal.conf')
         args = ["renew", "--reuse-key"]
         self._test_renewal_common(True, [], args=args, should_renew=True, reuse_key=True)
 
+    # Should be moved to renewal_test.py
     @mock.patch('sys.stdin')
     def test_noninteractive_renewal_delay(self, stdin):
         stdin.isatty.return_value = False
@@ -1107,6 +1114,7 @@ class MainTest(test_util.ConfigTestCase):  # pylint: disable=too-many-public-met
         sleep_call_arg = self.mock_sleep.call_args[0][0]
         self.assertTrue(1 <= sleep_call_arg <= 60*8)
 
+    # Should be moved to renewal_test.py
     @mock.patch('sys.stdin')
     def test_interactive_no_renewal_delay(self, stdin):
         stdin.isatty.return_value = True
@@ -1115,6 +1123,7 @@ class MainTest(test_util.ConfigTestCase):  # pylint: disable=too-many-public-met
         self._test_renewal_common(True, [], args=args, should_renew=True)
         self.assertEqual(self.mock_sleep.call_count, 0)
 
+    # Should be moved to renewal_test.py
     @mock.patch('certbot.renewal.should_renew')
     def test_renew_skips_recent_certs(self, should_renew):
         should_renew.return_value = False
@@ -1125,6 +1134,7 @@ class MainTest(test_util.ConfigTestCase):  # pylint: disable=too-many-public-met
         self.assertTrue('No renewals were attempted.' in stdout.getvalue())
         self.assertTrue('The following certs are not due for renewal yet:' in stdout.getvalue())
 
+    # Should be moved to renewal_test.py
     @test_util.broken_on_windows
     def test_quiet_renew(self):
         test_util.make_lineage(self.config.config_dir, 'sample-renewal.conf')
@@ -1139,12 +1149,14 @@ class MainTest(test_util.ConfigTestCase):  # pylint: disable=too-many-public-met
         out = stdout.getvalue()
         self.assertEqual("", out)
 
+    # Should be moved to renewal_test.py
     def test_renew_hook_validation(self):
         test_util.make_lineage(self.config.config_dir, 'sample-renewal.conf')
         args = ["renew", "--dry-run", "--post-hook=no-such-command"]
         self._test_renewal_common(True, [], args=args, should_renew=False,
                                   error_expected=True)
 
+    # Should be moved to renewal_test.py
     def test_renew_no_hook_validation(self):
         test_util.make_lineage(self.config.config_dir, 'sample-renewal.conf')
         args = ["renew", "--dry-run", "--post-hook=no-such-command",
@@ -1153,6 +1165,7 @@ class MainTest(test_util.ConfigTestCase):  # pylint: disable=too-many-public-met
             self._test_renewal_common(True, [], args=args, should_renew=True,
                                       error_expected=False)
 
+    # Should be moved to renewal_test.py
     def test_renew_verb_empty_config(self):
         rd = os.path.join(self.config.config_dir, 'renewal')
         if not os.path.exists(rd):
@@ -1162,11 +1175,13 @@ class MainTest(test_util.ConfigTestCase):  # pylint: disable=too-many-public-met
         args = ["renew", "--dry-run", "-tvv"]
         self._test_renewal_common(False, [], args=args, should_renew=False, error_expected=True)
 
+    # Should be moved to renewal_test.py
     def test_renew_with_certname(self):
         test_util.make_lineage(self.config.config_dir, 'sample-renewal.conf')
         self._test_renewal_common(True, [], should_renew=True,
             args=['renew', '--dry-run', '--cert-name', 'sample-renewal'])
 
+    # Should be moved to renewal_test.py
     def test_renew_with_bad_certname(self):
         self._test_renewal_common(True, [], should_renew=False,
             args=['renew', '--dry-run', '--cert-name', 'sample-renewal'],
@@ -1251,6 +1266,7 @@ class MainTest(test_util.ConfigTestCase):  # pylint: disable=too-many-public-met
             mock_reconstitute.side_effect = Exception
             self._test_renew_common(assert_oc_called=False, error_expected=True)
 
+    # Should be moved to renewal_test.py
     def test_renew_obtain_cert_error(self):
         self._make_dummy_renewal_config()
         with mock.patch('certbot.storage.RenewableCert') as mock_rc:
@@ -1264,12 +1280,14 @@ class MainTest(test_util.ConfigTestCase):  # pylint: disable=too-many-public-met
                 self._test_renewal_common(True, None, error_expected=True,
                                           args=['renew'], should_renew=False)
 
+    # Should be moved to renewal_test.py
     def test_renew_with_bad_cli_args(self):
         self._test_renewal_common(True, None, args='renew -d example.com'.split(),
                                   should_renew=False, error_expected=True)
         self._test_renewal_common(True, None, args='renew --csr {0}'.format(CSR).split(),
                                   should_renew=False, error_expected=True)
 
+    # Should be moved to renewal_test.py
     def test_no_renewal_with_hooks(self):
         _, _, stdout = self._test_renewal_common(
             due_for_renewal=False, extra_args=None, should_renew=False,

--- a/certbot/tests/main_test.py
+++ b/certbot/tests/main_test.py
@@ -1072,17 +1072,6 @@ class MainTest(test_util.ConfigTestCase):  # pylint: disable=too-many-public-met
             with open(log_path) as lf:
                 print(lf.read())
 
-    # Should be moved to renewal_test.py
-    @mock.patch('certbot.renewal.should_renew')
-    def test_renew_skips_recent_certs(self, should_renew):
-        should_renew.return_value = False
-        test_util.make_lineage(self.config.config_dir, 'sample-renewal.conf')
-        expiry = datetime.datetime.now() + datetime.timedelta(days=90)
-        _, _, stdout = self._test_renewal_common(False, extra_args=None, should_renew=False,
-                                                 args=['renew'], expiry_date=expiry)
-        self.assertTrue('No renewals were attempted.' in stdout.getvalue())
-        self.assertTrue('The following certs are not due for renewal yet:' in stdout.getvalue())
-
     def _make_dummy_renewal_config(self):
         renewer_configs_dir = os.path.join(self.config.config_dir, 'renewal')
         os.makedirs(renewer_configs_dir)

--- a/certbot/tests/main_test.py
+++ b/certbot/tests/main_test.py
@@ -1131,15 +1131,6 @@ class MainTest(test_util.ConfigTestCase):  # pylint: disable=too-many-public-met
         out = stdout.getvalue()
         self.assertEqual("", out)
 
-    # Should be moved to renewal_test.py
-    def test_renew_verb_empty_config(self):
-        rd = os.path.join(self.config.config_dir, 'renewal')
-        if not os.path.exists(rd):
-            os.makedirs(rd)
-        with open(os.path.join(rd, 'empty.conf'), 'w'):
-            pass  # leave the file empty
-        args = ["renew", "--dry-run", "-tvv"]
-        self._test_renewal_common(False, [], args=args, should_renew=False, error_expected=True)
 
     # Should be moved to renewal_test.py
     def test_renew_with_certname(self):

--- a/certbot/tests/main_test.py
+++ b/certbot/tests/main_test.py
@@ -1139,15 +1139,6 @@ class MainTest(test_util.ConfigTestCase):  # pylint: disable=too-many-public-met
         self.assertEqual("", out)
 
     # Should be moved to renewal_test.py
-    def test_renew_no_hook_validation(self):
-        test_util.make_lineage(self.config.config_dir, 'sample-renewal.conf')
-        args = ["renew", "--dry-run", "--post-hook=no-such-command",
-                "--disable-hook-validation"]
-        with mock.patch("certbot.hooks.post_hook"):
-            self._test_renewal_common(True, [], args=args, should_renew=True,
-                                      error_expected=False)
-
-    # Should be moved to renewal_test.py
     def test_renew_verb_empty_config(self):
         rd = os.path.join(self.config.config_dir, 'renewal')
         if not os.path.exists(rd):

--- a/certbot/tests/main_test.py
+++ b/certbot/tests/main_test.py
@@ -1084,13 +1084,6 @@ class MainTest(test_util.ConfigTestCase):  # pylint: disable=too-many-public-met
                 print(lf.read())
 
     # Should be moved to renewal_test.py
-    def test_renew_verb(self):
-        test_util.make_lineage(self.config.config_dir, 'sample-renewal.conf')
-        args = ["renew", "--dry-run", "-tvv"]
-        self._test_renewal_common(True, [], args=args, should_renew=True)
-
-
-    # Should be moved to renewal_test.py
     @mock.patch('sys.stdin')
     def test_noninteractive_renewal_delay(self, stdin):
         stdin.isatty.return_value = False

--- a/certbot/tests/main_test.py
+++ b/certbot/tests/main_test.py
@@ -1133,12 +1133,6 @@ class MainTest(test_util.ConfigTestCase):  # pylint: disable=too-many-public-met
 
 
     # Should be moved to renewal_test.py
-    def test_renew_with_certname(self):
-        test_util.make_lineage(self.config.config_dir, 'sample-renewal.conf')
-        self._test_renewal_common(True, [], should_renew=True,
-            args=['renew', '--dry-run', '--cert-name', 'sample-renewal'])
-
-    # Should be moved to renewal_test.py
     def test_renew_with_bad_certname(self):
         self._test_renewal_common(True, [], should_renew=False,
             args=['renew', '--dry-run', '--cert-name', 'sample-renewal'],

--- a/certbot/tests/main_test.py
+++ b/certbot/tests/main_test.py
@@ -1091,13 +1091,6 @@ class MainTest(test_util.ConfigTestCase):  # pylint: disable=too-many-public-met
 
 
     # Should be moved to renewal_test.py
-    @mock.patch('certbot.storage.RenewableCert.save_successor')
-    def test_reuse_key_no_dry_run(self, unused_save_successor):
-        test_util.make_lineage(self.config.config_dir, 'sample-renewal.conf')
-        args = ["renew", "--reuse-key"]
-        self._test_renewal_common(True, [], args=args, should_renew=True, reuse_key=True)
-
-    # Should be moved to renewal_test.py
     @mock.patch('sys.stdin')
     def test_noninteractive_renewal_delay(self, stdin):
         stdin.isatty.return_value = False

--- a/certbot/tests/main_test.py
+++ b/certbot/tests/main_test.py
@@ -1277,13 +1277,6 @@ class MainTest(test_util.ConfigTestCase):  # pylint: disable=too-many-public-met
                                           args=['renew'], should_renew=False)
 
     # Should be moved to renewal_test.py
-    def test_renew_with_bad_cli_args(self):
-        self._test_renewal_common(True, None, args='renew -d example.com'.split(),
-                                  should_renew=False, error_expected=True)
-        self._test_renewal_common(True, None, args='renew --csr {0}'.format(CSR).split(),
-                                  should_renew=False, error_expected=True)
-
-    # Should be moved to renewal_test.py
     def test_no_renewal_with_hooks(self):
         _, _, stdout = self._test_renewal_common(
             due_for_renewal=False, extra_args=None, should_renew=False,

--- a/certbot/tests/main_test.py
+++ b/certbot/tests/main_test.py
@@ -1097,15 +1097,6 @@ class MainTest(test_util.ConfigTestCase):  # pylint: disable=too-many-public-met
         self.assertTrue(1 <= sleep_call_arg <= 60*8)
 
     # Should be moved to renewal_test.py
-    @mock.patch('sys.stdin')
-    def test_interactive_no_renewal_delay(self, stdin):
-        stdin.isatty.return_value = True
-        test_util.make_lineage(self.config.config_dir, 'sample-renewal.conf')
-        args = ["renew", "--dry-run", "-tvv"]
-        self._test_renewal_common(True, [], args=args, should_renew=True)
-        self.assertEqual(self.mock_sleep.call_count, 0)
-
-    # Should be moved to renewal_test.py
     @mock.patch('certbot.renewal.should_renew')
     def test_renew_skips_recent_certs(self, should_renew):
         should_renew.return_value = False

--- a/certbot/tests/main_test.py
+++ b/certbot/tests/main_test.py
@@ -1084,19 +1084,6 @@ class MainTest(test_util.ConfigTestCase):  # pylint: disable=too-many-public-met
                 print(lf.read())
 
     # Should be moved to renewal_test.py
-    @mock.patch('sys.stdin')
-    def test_noninteractive_renewal_delay(self, stdin):
-        stdin.isatty.return_value = False
-        test_util.make_lineage(self.config.config_dir, 'sample-renewal.conf')
-        args = ["renew", "--dry-run", "-tvv"]
-        self._test_renewal_common(True, [], args=args, should_renew=True)
-        self.assertEqual(self.mock_sleep.call_count, 1)
-        # in main.py:
-        #     sleep_time = random.randint(1, 60*8)
-        sleep_call_arg = self.mock_sleep.call_args[0][0]
-        self.assertTrue(1 <= sleep_call_arg <= 60*8)
-
-    # Should be moved to renewal_test.py
     @mock.patch('certbot.renewal.should_renew')
     def test_renew_skips_recent_certs(self, should_renew):
         should_renew.return_value = False

--- a/certbot/tests/renewal_test.py
+++ b/certbot/tests/renewal_test.py
@@ -254,6 +254,19 @@ class RenewalTest(test_util.ConfigTestCase): # pylint: disable=too-many-public-m
         args = ["renew", "--dry-run", "-tvv"]
         self._test_renewal_common(False, [], args=args, should_renew=False, error_expected=True)
 
+    def test_renew_obtain_cert_error(self):
+        self._make_dummy_renewal_config()
+        with mock.patch('certbot.storage.RenewableCert') as mock_rc:
+            mock_lineage = mock.MagicMock()
+            mock_lineage.fullchain = "somewhere/fullchain.pem"
+            mock_rc.return_value = mock_lineage
+            mock_lineage.configuration = {
+                'renewalparams': {'authenticator': 'webroot'}}
+            with mock.patch('certbot.main.renew_cert') as mock_renew_cert:
+                mock_renew_cert.side_effect = Exception
+                self._test_renewal_common(True, None, error_expected=True,
+                                          args=['renew'], should_renew=False)
+
     @mock.patch('sys.stdin')
     def test_noninteractive_renewal_delay(self, stdin):
         stdin.isatty.return_value = False

--- a/certbot/tests/renewal_test.py
+++ b/certbot/tests/renewal_test.py
@@ -174,6 +174,32 @@ class RenewalTest(test_util.ConfigTestCase): # pylint: disable=too-many-public-m
 
         return mock_lineage, mock_get_utility, stdout
 
+    @test_util.broken_on_windows
+    @mock.patch('certbot.crypto_util.notAfter')
+    def test_certonly_renewal_trigger_callcount(self, unused_notafter):
+        # --dry-run should force renewal
+        _, get_utility, _ = self._test_renewal_common(False, ['--dry-run', '--keep'],
+                                                      log_out="simulating renewal")
+        self._test_renewal_common(False, ['--renew-by-default', '-tvv', '--debug'],
+                                  log_out="Auto-renewal forced")
+        self.assertEqual(get_utility().add_message.call_count, 1)
+
+    @test_util.broken_on_windows
+    @mock.patch('certbot.crypto_util.notAfter')
+    def test_certonly_renewal_trigger_dryrun_message(self, unused_notafter):
+        # --dry-run should force renewal
+        _, get_utility, _ = self._test_renewal_common(False, ['--dry-run', '--keep'],
+                                                      log_out="simulating renewal")
+
+        self.assertTrue('dry run' in get_utility().add_message.call_args[0][0])
+
+    @test_util.broken_on_windows
+    @mock.patch('certbot.crypto_util.notAfter')
+    def test_certonly_negative_renewal(self, unused_notafter):
+        """Testing negatie renewal trigger, should not renew."""
+
+        self._test_renewal_common(False, ['-tvv', '--debug', '--keep'],
+                                  log_out="not yet due", should_renew=False)
     def _make_dummy_renewal_config(self):
         renewer_configs_dir = os.path.join(self.config.config_dir, 'renewal')
         os.makedirs(renewer_configs_dir)

--- a/certbot/tests/renewal_test.py
+++ b/certbot/tests/renewal_test.py
@@ -1,3 +1,4 @@
+# coding=utf-8
 """Tests for certbot.renewal"""
 from __future__ import print_function
 
@@ -6,8 +7,10 @@ import sys
 import mock
 import unittest
 import datetime
+import json
 import os
 import six
+import tempfile
 import traceback
 
 from acme import challenges
@@ -22,7 +25,7 @@ import certbot.tests.util as test_util
 CSR = test_util.vector_path('csr_512.der')
 
 
-class RenewalTest(test_util.ConfigTestCase):
+class RenewalTest(test_util.ConfigTestCase): # pylint: disable=too-many-public-methods
     def setUp(self):
         super(RenewalTest, self).setUp()
         self.standard_args = ['--config-dir', self.config.config_dir,
@@ -171,6 +174,33 @@ class RenewalTest(test_util.ConfigTestCase):
 
         return mock_lineage, mock_get_utility, stdout
 
+    def _make_dummy_renewal_config(self):
+        renewer_configs_dir = os.path.join(self.config.config_dir, 'renewal')
+        os.makedirs(renewer_configs_dir)
+        with open(os.path.join(renewer_configs_dir, 'test.conf'), 'w') as f:
+            f.write("My contents don't matter")
+
+    def _test_renew_common(self, renewalparams=None, names=None,
+                           assert_oc_called=None, **kwargs):
+        self._make_dummy_renewal_config()
+        with mock.patch('certbot.storage.RenewableCert') as mock_rc:
+            mock_lineage = mock.MagicMock()
+            mock_lineage.fullchain = "somepath/fullchain.pem"
+            if renewalparams is not None:
+                mock_lineage.configuration = {'renewalparams': renewalparams}
+            if names is not None:
+                mock_lineage.names.return_value = names
+            mock_rc.return_value = mock_lineage
+            with mock.patch('certbot.main.renew_cert') as mock_renew_cert:
+                kwargs.setdefault('args', ['renew'])
+                self._test_renewal_common(True, None, should_renew=False, **kwargs)
+
+            if assert_oc_called is not None:
+                if assert_oc_called:
+                    self.assertTrue(mock_renew_cert.called)
+                else:
+                    self.assertFalse(mock_renew_cert.called)
+
     def test_renew_with_bad_certname(self):
         self._test_renewal_common(True, [], should_renew=False,
                                   args=['renew', '--dry-run', '--cert-name', 'sample-renewal'],
@@ -260,6 +290,58 @@ class RenewalTest(test_util.ConfigTestCase):
                                                  should_renew=True, quiet_mode=True)
         out = stdout.getvalue()
         self.assertEqual("", out)
+
+    def test_renew_no_renewalparams(self):
+        self._test_renew_common(assert_oc_called=False, error_expected=True)
+
+    def test_renew_no_authenticator(self):
+        self._test_renew_common(renewalparams={}, assert_oc_called=False,
+            error_expected=True)
+
+    def test_renew_with_bad_int(self):
+        renewalparams = {'authenticator': 'webroot',
+                         'rsa_key_size': 'over 9000'}
+        self._test_renew_common(renewalparams=renewalparams, error_expected=True,
+                                assert_oc_called=False)
+
+    def test_renew_with_nonetype_http01(self):
+        renewalparams = {'authenticator': 'webroot',
+                         'http01_port': 'None'}
+        self._test_renew_common(renewalparams=renewalparams,
+                                assert_oc_called=True)
+
+    def test_renew_with_bad_domain(self):
+        renewalparams = {'authenticator': 'webroot'}
+        names = ['uniçodé.com']
+        self._test_renew_common(renewalparams=renewalparams, error_expected=True,
+                                names=names, assert_oc_called=False)
+
+    @mock.patch('certbot.plugins.selection.choose_configurator_plugins')
+    def test_renew_with_configurator(self, mock_sel):
+        mock_sel.return_value = (mock.MagicMock(), mock.MagicMock())
+        renewalparams = {'authenticator': 'webroot'}
+        self._test_renew_common(
+            renewalparams=renewalparams, assert_oc_called=True,
+            args='renew --configurator apache'.split())
+
+    def test_renew_plugin_config_restoration(self):
+        renewalparams = {'authenticator': 'webroot',
+                         'webroot_path': 'None',
+                         'webroot_imaginary_flag': '42'}
+        self._test_renew_common(renewalparams=renewalparams,
+                                assert_oc_called=True)
+
+    def test_renew_with_webroot_map(self):
+        renewalparams = {'authenticator': 'webroot'}
+        self._test_renew_common(
+            renewalparams=renewalparams, assert_oc_called=True,
+            args=['renew', '--webroot-map', json.dumps({'example.com': tempfile.gettempdir()})])
+
+    def test_renew_reconstitute_error(self):
+        # pylint: disable=protected-access
+        with mock.patch('certbot.main.renewal._reconstitute') as mock_reconstitute:
+            mock_reconstitute.side_effect = Exception
+            self._test_renew_common(assert_oc_called=False, error_expected=True)
 
     @mock.patch('certbot.renewal.should_renew')
     def test_renew_skips_recent_certs(self, should_renew):

--- a/certbot/tests/renewal_test.py
+++ b/certbot/tests/renewal_test.py
@@ -167,6 +167,12 @@ class RenewalTest(test_util.ConfigTestCase):
 
         return mock_lineage, mock_get_utility, stdout
 
+    @mock.patch('certbot.storage.RenewableCert.save_successor')
+    def test_reuse_key_no_dry_run(self, unused_save_successor):
+        test_util.make_lineage(self.config.config_dir, 'sample-renewal.conf')
+        args = ["renew", "--reuse-key"]
+        self._test_renewal_common(True, [], args=args, should_renew=True, reuse_key=True)
+
 
     def test_renew_hook_validation(self):
         test_util.make_lineage(self.config.config_dir, 'sample-renewal.conf')

--- a/certbot/tests/renewal_test.py
+++ b/certbot/tests/renewal_test.py
@@ -259,6 +259,20 @@ class RenewalTest(test_util.ConfigTestCase):
         out = stdout.getvalue()
         self.assertEqual("", out)
 
+    def test_certonly_renewal_lineage(self):
+        lineage, _, _ = self._test_renewal_common(True, [])
+        self.assertEqual(lineage.save_successor.call_count, 1)
+        lineage.update_all_links_to.assert_called_once_with(
+            lineage.latest_common_version())
+
+    @mock.patch('certbot.crypto_util.notAfter')
+    def test_certonly_renewal_get_utillity(self, unused_notafter):
+        _, get_utility, _ = self._test_renewal_common(True, [])
+
+        cert_msg = get_utility().add_message.call_args_list[0][0][0]
+        self.assertTrue('fullchain.pem' in cert_msg)
+        self.assertTrue('donate' in get_utility().add_message.call_args[0][0])
+
 
 class RestoreRequiredConfigElementsTest(test_util.ConfigTestCase):
     """Tests for certbot.renewal.restore_required_config_elements."""

--- a/certbot/tests/renewal_test.py
+++ b/certbot/tests/renewal_test.py
@@ -167,6 +167,13 @@ class RenewalTest(test_util.ConfigTestCase):
 
         return mock_lineage, mock_get_utility, stdout
 
+
+    def test_renew_hook_validation(self):
+        test_util.make_lineage(self.config.config_dir, 'sample-renewal.conf')
+        args = ["renew", "--dry-run", "--post-hook=no-such-command"]
+        self._test_renewal_common(True, [], args=args, should_renew=False,
+                                  error_expected=True)
+
     def test_renew_bad_cli_args_with_split(self):
         self._test_renewal_common(True, None, args='renew -d example.com'.split(),
                                   should_renew=False, error_expected=True)
@@ -174,6 +181,7 @@ class RenewalTest(test_util.ConfigTestCase):
     def test_renew_bad_cli_args_with_format(self):
         self._test_renewal_common(True, None, args='renew --csr {0}'.format(CSR).split(),
                                   should_renew=False, error_expected=True)
+
 
 
 class RestoreRequiredConfigElementsTest(test_util.ConfigTestCase):

--- a/certbot/tests/renewal_test.py
+++ b/certbot/tests/renewal_test.py
@@ -200,6 +200,14 @@ class RenewalTest(test_util.ConfigTestCase):
         self._test_renewal_common(True, None, args='renew --csr {0}'.format(CSR).split(),
                                   should_renew=False, error_expected=True)
 
+    def test_renew_verb_empty_config(self):
+        rd = os.path.join(self.config.config_dir, 'renewal')
+        if not os.path.exists(rd):
+            os.makedirs(rd)
+        with open(os.path.join(rd, 'empty.conf'), 'w'):
+            pass  # leave the file empty
+        args = ["renew", "--dry-run", "-tvv"]
+        self._test_renewal_common(False, [], args=args, should_renew=False, error_expected=True)
 
 class RestoreRequiredConfigElementsTest(test_util.ConfigTestCase):
     """Tests for certbot.renewal.restore_required_config_elements."""

--- a/certbot/tests/renewal_test.py
+++ b/certbot/tests/renewal_test.py
@@ -33,6 +33,11 @@ class RenewalTest(test_util.ConfigTestCase):
             with open(log_path) as lf:
                 print(lf.read())
 
+    def test_reuse_key(self):
+        test_util.make_lineage(self.config.config_dir, 'sample-renewal.conf')
+        args = ["renew", "--dry-run", "--reuse-key"]
+        self._test_renewal_common(True, [], args=args, should_renew=True, reuse_key=True)
+
     def _call(self, args, stdout=None, mockisfile=False):
         """Run the cli with output streams, actual client and optionally
         os.path.isfile() mocked out"""

--- a/certbot/tests/renewal_test.py
+++ b/certbot/tests/renewal_test.py
@@ -1,6 +1,8 @@
 """Tests for certbot.renewal"""
 from __future__ import print_function
 
+import sys
+
 import mock
 import unittest
 import datetime
@@ -282,6 +284,14 @@ class RenewalTest(test_util.ConfigTestCase):
         cert_msg = get_utility().add_message.call_args_list[0][0][0]
         self.assertTrue('fullchain.pem' in cert_msg)
         self.assertTrue('donate' in get_utility().add_message.call_args[0][0])
+
+    def test_no_renewal_with_hooks(self):
+        _, _, stdout = self._test_renewal_common(
+            due_for_renewal=False, extra_args=None, should_renew=False,
+            args=['renew', '--post-hook',
+                  '{0} -c "from __future__ import print_function; print(\'hello world\');"'
+                  .format(sys.executable)])
+        self.assertTrue('No hooks were run.' in stdout.getvalue())
 
 
 class RestoreRequiredConfigElementsTest(test_util.ConfigTestCase):

--- a/certbot/tests/renewal_test.py
+++ b/certbot/tests/renewal_test.py
@@ -15,8 +15,9 @@ from certbot import errors
 from certbot import storage
 from certbot import main
 
-
 import certbot.tests.util as test_util
+
+CSR = test_util.vector_path('csr_512.der')
 
 
 class RenewalTest(test_util.ConfigTestCase):
@@ -165,6 +166,14 @@ class RenewalTest(test_util.ConfigTestCase):
                     self.assertTrue(log_out in lf.read())
 
         return mock_lineage, mock_get_utility, stdout
+
+    def test_renew_bad_cli_args_with_split(self):
+        self._test_renewal_common(True, None, args='renew -d example.com'.split(),
+                                  should_renew=False, error_expected=True)
+
+    def test_renew_bad_cli_args_with_format(self):
+        self._test_renewal_common(True, None, args='renew --csr {0}'.format(CSR).split(),
+                                  should_renew=False, error_expected=True)
 
 
 class RestoreRequiredConfigElementsTest(test_util.ConfigTestCase):

--- a/certbot/tests/renewal_test.py
+++ b/certbot/tests/renewal_test.py
@@ -167,6 +167,13 @@ class RenewalTest(test_util.ConfigTestCase):
 
         return mock_lineage, mock_get_utility, stdout
 
+    @mock.patch('certbot.hooks.post_hook')
+    def test_renew_no_hook_validation(self, unused_post_hook):
+        test_util.make_lineage(self.config.config_dir, 'sample-renewal.conf')
+        args = ["renew", "--dry-run", "--post-hook=no-such-command",
+                "--disable-hook-validation"]
+        self._test_renewal_common(True, [], args=args, should_renew=True,
+                                      error_expected=False)
     @mock.patch('certbot.storage.RenewableCert.save_successor')
     def test_reuse_key_no_dry_run(self, unused_save_successor):
         test_util.make_lineage(self.config.config_dir, 'sample-renewal.conf')
@@ -187,7 +194,6 @@ class RenewalTest(test_util.ConfigTestCase):
     def test_renew_bad_cli_args_with_format(self):
         self._test_renewal_common(True, None, args='renew --csr {0}'.format(CSR).split(),
                                   should_renew=False, error_expected=True)
-
 
 
 class RestoreRequiredConfigElementsTest(test_util.ConfigTestCase):

--- a/certbot/tests/renewal_test.py
+++ b/certbot/tests/renewal_test.py
@@ -214,6 +214,18 @@ class RenewalTest(test_util.ConfigTestCase):
                                   should_renew=False, error_expected=True)
 
     @mock.patch('sys.stdin')
+    def test_noninteractive_renewal_delay(self, stdin):
+        stdin.isatty.return_value = False
+        test_util.make_lineage(self.config.config_dir, 'sample-renewal.conf')
+        args = ["renew", "--dry-run", "-tvv"]
+        self._test_renewal_common(True, [], args=args, should_renew=True)
+        self.assertEqual(self.mock_sleep.call_count, 1)
+        # in main.py:
+        #     sleep_time = random.randint(1, 60*8)
+        sleep_call_arg = self.mock_sleep.call_args[0][0]
+        self.assertTrue(1 <= sleep_call_arg <= 60*8)
+
+    @mock.patch('sys.stdin')
     def test_interactive_no_renewal_delay(self, stdin):
         stdin.isatty.return_value = True
         test_util.make_lineage(self.config.config_dir, 'sample-renewal.conf')

--- a/certbot/tests/renewal_test.py
+++ b/certbot/tests/renewal_test.py
@@ -167,6 +167,11 @@ class RenewalTest(test_util.ConfigTestCase):
 
         return mock_lineage, mock_get_utility, stdout
 
+    def test_renew_verb(self):
+        test_util.make_lineage(self.config.config_dir, 'sample-renewal.conf')
+        args = ["renew", "--dry-run", "-tvv"]
+        self._test_renewal_common(True, [], args=args, should_renew=True)
+
     @mock.patch('certbot.hooks.post_hook')
     def test_renew_no_hook_validation(self, unused_post_hook):
         test_util.make_lineage(self.config.config_dir, 'sample-renewal.conf')

--- a/certbot/tests/renewal_test.py
+++ b/certbot/tests/renewal_test.py
@@ -233,6 +233,23 @@ class RenewalTest(test_util.ConfigTestCase):
         self._test_renewal_common(True, [], args=args, should_renew=True)
         self.assertEqual(self.mock_sleep.call_count, 0)
 
+    @test_util.broken_on_windows
+    def test_renew(self):
+        test_util.make_lineage(self.config.config_dir, 'sample-renewal.conf')
+        args = ["renew", "--dry-run"]
+        _, _, stdout = self._test_renewal_common(True, [], args=args, should_renew=True)
+        out = stdout.getvalue()
+        self.assertTrue("renew" in out)
+
+    @test_util.broken_on_windows
+    def test_quiet_renew(self):
+        test_util.make_lineage(self.config.config_dir, 'sample-renewal.conf')
+        args = ["renew", "--dry-run", "-q"]
+        _, _, stdout = self._test_renewal_common(True, [], args=args,
+                                                 should_renew=True, quiet_mode=True)
+        out = stdout.getvalue()
+        self.assertEqual("", out)
+
 
 class RestoreRequiredConfigElementsTest(test_util.ConfigTestCase):
     """Tests for certbot.renewal.restore_required_config_elements."""

--- a/certbot/tests/renewal_test.py
+++ b/certbot/tests/renewal_test.py
@@ -213,6 +213,15 @@ class RenewalTest(test_util.ConfigTestCase):
         self._test_renewal_common(True, None, args='renew --csr {0}'.format(CSR).split(),
                                   should_renew=False, error_expected=True)
 
+    def test_renew_verb_empty_config(self):
+        rd = os.path.join(self.config.config_dir, 'renewal')
+        if not os.path.exists(rd):
+            os.makedirs(rd)
+        with open(os.path.join(rd, 'empty.conf'), 'w'):
+            pass  # leave the file empty
+        args = ["renew", "--dry-run", "-tvv"]
+        self._test_renewal_common(False, [], args=args, should_renew=False, error_expected=True)
+
     @mock.patch('sys.stdin')
     def test_noninteractive_renewal_delay(self, stdin):
         stdin.isatty.return_value = False

--- a/certbot/tests/renewal_test.py
+++ b/certbot/tests/renewal_test.py
@@ -167,6 +167,11 @@ class RenewalTest(test_util.ConfigTestCase):
 
         return mock_lineage, mock_get_utility, stdout
 
+    def test_renew_with_certname(self):
+        test_util.make_lineage(self.config.config_dir, 'sample-renewal.conf')
+        self._test_renewal_common(True, [], should_renew=True,
+                                  args=['renew', '--dry-run', '--cert-name', 'sample-renewal'])
+
     def test_renew_verb(self):
         test_util.make_lineage(self.config.config_dir, 'sample-renewal.conf')
         args = ["renew", "--dry-run", "-tvv"]
@@ -179,6 +184,7 @@ class RenewalTest(test_util.ConfigTestCase):
                 "--disable-hook-validation"]
         self._test_renewal_common(True, [], args=args, should_renew=True,
                                       error_expected=False)
+
     @mock.patch('certbot.storage.RenewableCert.save_successor')
     def test_reuse_key_no_dry_run(self, unused_save_successor):
         test_util.make_lineage(self.config.config_dir, 'sample-renewal.conf')

--- a/certbot/tests/renewal_test.py
+++ b/certbot/tests/renewal_test.py
@@ -167,6 +167,11 @@ class RenewalTest(test_util.ConfigTestCase):
 
         return mock_lineage, mock_get_utility, stdout
 
+    def test_renew_with_bad_certname(self):
+        self._test_renewal_common(True, [], should_renew=False,
+                                  args=['renew', '--dry-run', '--cert-name', 'sample-renewal'],
+                                  error_expected=True)
+
     def test_renew_with_certname(self):
         test_util.make_lineage(self.config.config_dir, 'sample-renewal.conf')
         self._test_renewal_common(True, [], should_renew=True,


### PR DESCRIPTION
This patch refactors tests as stated in #4069.

Fix #4069