### PR TITLE
Refactor test_renew_obtain_cert_error() - Fix #43

### DIFF
--- a/certbot/tests/main_test.py
+++ b/certbot/tests/main_test.py
@@ -1069,12 +1069,6 @@ class MainTest(test_util.ConfigTestCase):  # pylint: disable=too-many-public-met
             with open(log_path) as lf:
                 print(lf.read())
 
-    def _make_dummy_renewal_config(self):
-        renewer_configs_dir = os.path.join(self.config.config_dir, 'renewal')
-        os.makedirs(renewer_configs_dir)
-        with open(os.path.join(renewer_configs_dir, 'test.conf'), 'w') as f:
-            f.write("My contents don't matter")
-
     @test_util.patch_get_utility()
     @mock.patch('certbot.main._find_lineage_for_domains_and_certname')
     @mock.patch('certbot.main._init_le_client')

--- a/certbot/tests/main_test.py
+++ b/certbot/tests/main_test.py
@@ -1075,20 +1075,6 @@ class MainTest(test_util.ConfigTestCase):  # pylint: disable=too-many-public-met
         with open(os.path.join(renewer_configs_dir, 'test.conf'), 'w') as f:
             f.write("My contents don't matter")
 
-    # Should be moved to renewal_test.py
-    def test_renew_obtain_cert_error(self):
-        self._make_dummy_renewal_config()
-        with mock.patch('certbot.storage.RenewableCert') as mock_rc:
-            mock_lineage = mock.MagicMock()
-            mock_lineage.fullchain = "somewhere/fullchain.pem"
-            mock_rc.return_value = mock_lineage
-            mock_lineage.configuration = {
-                'renewalparams': {'authenticator': 'webroot'}}
-            with mock.patch('certbot.main.renew_cert') as mock_renew_cert:
-                mock_renew_cert.side_effect = Exception
-                self._test_renewal_common(True, None, error_expected=True,
-                                          args=['renew'], should_renew=False)
-
     @test_util.patch_get_utility()
     @mock.patch('certbot.main._find_lineage_for_domains_and_certname')
     @mock.patch('certbot.main._init_le_client')

--- a/certbot/tests/renewal_test.py
+++ b/certbot/tests/renewal_test.py
@@ -254,6 +254,19 @@ class RenewalTest(test_util.ConfigTestCase): # pylint: disable=too-many-public-m
         args = ["renew", "--dry-run", "-tvv"]
         self._test_renewal_common(False, [], args=args, should_renew=False, error_expected=True)
 
+    def test_renew_obtain_cert_error(self):
+        self._make_dummy_renewal_config()
+        with mock.patch('certbot.storage.RenewableCert') as mock_rc:
+            mock_lineage = mock.MagicMock()
+            mock_lineage.fullchain = "somewhere/fullchain.pem"
+            mock_rc.return_value = mock_lineage
+            mock_lineage.configuration = {
+                'renewalparams': {'authenticator': 'webroot'}}
+            with mock.patch('certbot.main.renew_cert') as mock_renew_cert:
+                mock_renew_cert.side_effect = Exception
+                self._test_renewal_common(True, None, error_expected=True,
+                                          args=['renew'], should_renew=False)
+
     @mock.patch('sys.stdin')
     def test_noninteractive_renewal_delay(self, stdin):
         stdin.isatty.return_value = False


### PR DESCRIPTION
Move test_renew_obtain_cert_error from main_test to renewal_test